### PR TITLE
Fix/unity initializer refactoring

### DIFF
--- a/adapters/Unity/UnityAdapter/GADMAdapterUnityBannerAd.m
+++ b/adapters/Unity/UnityAdapter/GADMAdapterUnityBannerAd.m
@@ -70,6 +70,18 @@
     return;
   }
 
+  GADAdSize supportedSize = [self supportedAdSizeFromRequestedSize:adSize];
+  if (!IsGADAdSizeValid(supportedSize)) {
+    NSString *errorMsg = [NSString
+        stringWithFormat:
+            @"UnityAds supported banner sizes are not a good fit for the requested size: %@",
+            NSStringFromGADAdSize(adSize)];
+    NSError *error =
+        GADMAdapterUnityErrorWithCodeAndDescription(GADMAdapterUnityErrorSizeMismatch, errorMsg);
+    [strongConnector adapter:strongAdapter didFailAd:error];
+    return;
+  }
+
   if (![UnityAds isInitialized]) {
     [[GADMAdapterUnity alloc] initializeWithGameID:_gameID withInitDelegate:Nil];
   }
@@ -87,6 +99,13 @@
 - (void)stopBeingDelegate {
   _bannerAd = nil;
   _bannerAd.delegate = nil;
+}
+
+// Find closest supported ad size from a given ad size.
+- (GADAdSize)supportedAdSizeFromRequestedSize:(GADAdSize)gadAdSize {
+  NSArray *potentials =
+      @[ NSValueFromGADAdSize(kGADAdSizeBanner), NSValueFromGADAdSize(kGADAdSizeLeaderboard) ];
+  return GADClosestValidSizeForAdSizes(gadAdSize, potentials);
 }
 
 #pragma mark UADSBannerView Delegate methods

--- a/adapters/Unity/UnityAdapter/GADMUnityInitializer.m
+++ b/adapters/Unity/UnityAdapter/GADMUnityInitializer.m
@@ -90,24 +90,12 @@
 
 - (void)getInterstitial {
   id<GADMAdNetworkConnector> strongConnector = _networkConnector;
-  if (!strongConnector) return;
-  _gameID = [[[strongConnector credentials] objectForKey:kGADMAdapterUnityGameID] copy];
+  
   _interstitialAd = [[GADMUnityInterstitialAd alloc] initWithGADMAdNetworkConnector:strongConnector adapter:self];
-  if (!_interstitialAd) {
-    NSString *description = [NSString
-                             stringWithFormat:@"%@ initialization failed!", NSStringFromClass([GADMUnityInterstitialAd class])];
-    NSError *error = GADMAdapterUnityErrorWithCodeAndDescription(GADMAdapterUnityErrorAdInitializationFailure, description);
-    [strongConnector adapter:self didFailAd:error];
-    return;
-  }
   [_interstitialAd getInterstitial];
 }
 
 - (void)presentInterstitialFromRootViewController:(UIViewController *)rootViewController {
-  id<GADMAdNetworkConnector> strongConnector = _networkConnector;
-  if (strongConnector) {
-    [strongConnector adapterWillPresentInterstitial:self];
-  }
   [_interstitialAd presentInterstitialFromRootViewController:rootViewController];
 }
 
@@ -116,47 +104,9 @@
 - (void)getBannerWithSize:(GADAdSize)adSize {
   id<GADMAdNetworkConnector> strongConnector = _networkConnector;
 
-  if (!strongConnector) {
-    NSLog(@"Adapter Error: No GADMAdNetworkConnector found.");
-
-    return;
-  }
-  GADAdSize supportedSize = [self supportedAdSizeFromRequestedSize:adSize];
-  if (!IsGADAdSizeValid(supportedSize)) {
-    NSString *errorMsg = [NSString
-        stringWithFormat:
-            @"UnityAds supported banner sizes are not a good fit for the requested size: %@",
-            NSStringFromGADAdSize(adSize)];
-    NSError *error =
-        GADMAdapterUnityErrorWithCodeAndDescription(GADMAdapterUnityErrorSizeMismatch, errorMsg);
-    [strongConnector adapter:self didFailAd:error];
-    return;
-  }
-  _gameID = [strongConnector.credentials[kGADMAdapterUnityGameID] copy];
-  _placementID = [strongConnector.credentials[kGADMAdapterUnityPlacementID] copy];
-  if (!_gameID || !_placementID) {
-    NSError *error = GADMAdapterUnityErrorWithCodeAndDescription( GADMAdapterUnityErrorInvalidServerParameters, kMISSING_ID_ERROR);
-    [strongConnector adapter:self didFailAd:error];
-    return;
-  }
   _bannerAd = [[GADMAdapterUnityBannerAd alloc] initWithGADMAdNetworkConnector:strongConnector
                                                                        adapter:self];
-
-  if (!_bannerAd) {
-    NSString *description = [NSString
-                             stringWithFormat:@"%@ initialization failed!", NSStringFromClass([GADMAdapterUnityBannerAd class])];
-    NSError *error = GADMAdapterUnityErrorWithCodeAndDescription(GADMAdapterUnityErrorAdInitializationFailure, description);
-    [strongConnector adapter:self didFailAd:error];
-    return;
-  }
-  [_bannerAd loadBannerWithSize:supportedSize];
-}
-
-/// Find closest supported ad size from a given ad size.
-- (GADAdSize)supportedAdSizeFromRequestedSize:(GADAdSize)gadAdSize {
-  NSArray *potentials =
-      @[ NSValueFromGADAdSize(kGADAdSizeBanner), NSValueFromGADAdSize(kGADAdSizeLeaderboard) ];
-  return GADClosestValidSizeForAdSizes(gadAdSize, potentials);
+  [_bannerAd loadBannerWithSize:adSize];
 }
 
 @end


### PR DESCRIPTION
Move Banner Size check and adjustment logic into BannerAd class.

Remove duplicates GADMAdNetworkConnector calls from GADMUnityInitializer.m
