### PR TITLE
Fix/remove constant error

### DIFF
--- a/adapters/Unity/UnityAdapter/GADMAdapterUnityBannerAd.h
+++ b/adapters/Unity/UnityAdapter/GADMAdapterUnityBannerAd.h
@@ -19,7 +19,7 @@
 @interface GADMAdapterUnityBannerAd : NSObject
 
 /// Initializes a new instance with |connector| and |adapter|.
-- (instancetype)initWithGADMAdNetworkConnector:(nonnull id<GADMAdNetworkConnector>)connector
+- (nonnull instancetype)initWithGADMAdNetworkConnector:(nonnull id<GADMAdNetworkConnector>)connector
                                              adapter:(nonnull id<GADMAdNetworkAdapter>)adapter
   NS_DESIGNATED_INITIALIZER;
 

--- a/adapters/Unity/UnityAdapter/GADMAdapterUnityBannerAd.m
+++ b/adapters/Unity/UnityAdapter/GADMAdapterUnityBannerAd.m
@@ -39,7 +39,7 @@
   NSString *_placementID;
 }
 
-- (instancetype)initWithGADMAdNetworkConnector:(nonnull id<GADMAdNetworkConnector>)connector
+- (nonnull instancetype)initWithGADMAdNetworkConnector:(nonnull id<GADMAdNetworkConnector>)connector
                                        adapter:(nonnull id<GADMAdNetworkAdapter>)adapter {
   self = [super init];
   if (self) {

--- a/adapters/Unity/UnityAdapter/GADMAdapterUnityBannerAd.m
+++ b/adapters/Unity/UnityAdapter/GADMAdapterUnityBannerAd.m
@@ -66,7 +66,8 @@
   _gameID = [[[strongConnector credentials] objectForKey:kGADMAdapterUnityGameID] copy];
   _placementID = [strongConnector.credentials[kGADMAdapterUnityPlacementID] copy];
   if (!_gameID || !_placementID) {
-    NSError *error = GADUnityErrorWithDescription(kMISSING_ID_ERROR);
+    NSError *error = GADMAdapterUnityErrorWithCodeAndDescription(
+           GADMAdapterUnityErrorInvalidServerParameters, @"Game ID and Placement ID cannot be nil.");
     [strongConnector adapter:strongAdapter didFailAd:error];
     return;
   }

--- a/adapters/Unity/UnityAdapter/GADMAdapterUnityRewardedAd.m
+++ b/adapters/Unity/UnityAdapter/GADMAdapterUnityRewardedAd.m
@@ -21,16 +21,15 @@
 @interface GADMAdapterUnityRewardedAd () <GADMediationRewardedAd, UnityAdsExtendedDelegate, UnityAdsLoadDelegate> {
   // The completion handler to call when the ad loading succeeds or fails.
   GADMediationRewardedLoadCompletionHandler _adLoadCompletionHandler;
-  
   // Ad configuration for the ad to be rendered.
   GADMediationAdConfiguration *_adConfiguration;
-  
+
   // An ad event delegate to invoke when ad rendering events occur.
   id<GADMediationRewardedAdEventDelegate> _adEventDelegate;
-  
+
   /// Game ID of Unity Ads network.
   NSString *_gameID;
-  
+
   /// Placement ID of Unity Ads network.
   NSString *_placementID;
 }
@@ -61,7 +60,7 @@
     }
     return;
   }
-  
+
   if (![UnityAds isSupported]) {
     NSString *description =
     [[NSString alloc] initWithFormat:@"%@ is not supported for this device.",
@@ -121,7 +120,7 @@
                                                                  @"UnityAds finished presenting with error state kUnityAdsFinishStateError.");
     [_adEventDelegate didFailToPresentWithError:error];
   }
-  
+
   [_adEventDelegate willDismissFullScreenView];
   [_adEventDelegate didDismissFullScreenView];
 }

--- a/adapters/Unity/UnityAdapter/GADMAdapterUnityUtils.m
+++ b/adapters/Unity/UnityAdapter/GADMAdapterUnityUtils.m
@@ -32,7 +32,7 @@ void GADMUnityConfigureMediationService(void) {
 NSError *_Nonnull GADMAdapterUnityErrorWithCodeAndDescription(GADMAdapterUnityErrorCode code,
                                                               NSString *_Nonnull description) {
   NSDictionary *userInfo =
-  @{NSLocalizedDescriptionKey : description, NSLocalizedFailureReasonErrorKey : description};
+    @{NSLocalizedDescriptionKey : description, NSLocalizedFailureReasonErrorKey : description};
   NSError *error = [NSError errorWithDomain:GADMAdapterUnityErrorDomain
                                        code:code
                                    userInfo:userInfo];
@@ -42,7 +42,7 @@ NSError *_Nonnull GADMAdapterUnityErrorWithCodeAndDescription(GADMAdapterUnityEr
 NSError *_Nonnull GADMAdapterUnitySDKErrorWithUnityAdsErrorAndMessage(UnityAdsError errorCode,
                                                                       NSString *_Nonnull message) {
   NSDictionary *userInfo =
-  @{NSLocalizedDescriptionKey : message, NSLocalizedFailureReasonErrorKey : message};
+    @{NSLocalizedDescriptionKey : message, NSLocalizedFailureReasonErrorKey : message};
   NSError *error = [NSError errorWithDomain:GADMAdapterUnitySDKErrorDomain
                                        code:errorCode
                                    userInfo:userInfo];

--- a/adapters/Unity/UnityAdapter/GADMUnityInitializer.m
+++ b/adapters/Unity/UnityAdapter/GADMUnityInitializer.m
@@ -96,7 +96,7 @@
   if (!_interstitialAd) {
     NSString *description = [NSString
                              stringWithFormat:@"%@ initialization failed!", NSStringFromClass([GADMUnityInterstitialAd class])];
-    NSError *error = GADMAdapterUnityErrorWithCodeAndDescription(GADMAdapterUnityErrorAdInitializationFailure, description);
+    NSError *error = GADMAdapterUnityErrorWithCodeAndDescription(GADMAdapterUnityErrorAdObjectNil, description);
     [strongConnector adapter:self didFailAd:error];
     return;
   }
@@ -135,7 +135,7 @@
   _gameID = [strongConnector.credentials[kGADMAdapterUnityGameID] copy];
   _placementID = [strongConnector.credentials[kGADMAdapterUnityPlacementID] copy];
   if (!_gameID || !_placementID) {
-    NSError *error = GADMAdapterUnityErrorWithCodeAndDescription( GADMAdapterUnityErrorInvalidServerParameters, kMISSING_ID_ERROR);
+    NSError *error = GADMAdapterUnityErrorWithCodeAndDescription( GADMAdapterUnityErrorInvalidServerParameters, @"Game ID and Placement ID cannot be nil.");
     [strongConnector adapter:self didFailAd:error];
     return;
   }
@@ -145,7 +145,7 @@
   if (!_bannerAd) {
     NSString *description = [NSString
                              stringWithFormat:@"%@ initialization failed!", NSStringFromClass([GADMAdapterUnityBannerAd class])];
-    NSError *error = GADMAdapterUnityErrorWithCodeAndDescription(GADMAdapterUnityErrorAdInitializationFailure, description);
+    NSError *error = GADMAdapterUnityErrorWithCodeAndDescription(GADMAdapterUnityErrorAdObjectNil, description);
     [strongConnector adapter:self didFailAd:error];
     return;
   }

--- a/adapters/Unity/UnityAdapter/GADMUnityInterstitialAd.m
+++ b/adapters/Unity/UnityAdapter/GADMUnityInterstitialAd.m
@@ -16,6 +16,7 @@
 #import "GADMAdapterUnityConstants.h"
 #import "GADUnityError.h"
 #import "GADMUnityInitializer.h"
+#import "GADMAdapterUnityUtils.h"
 
 @interface GADMUnityInterstitialAd ()
 @end
@@ -59,7 +60,8 @@
   _gameID = [[[strongConnector credentials] objectForKey:kGADMAdapterUnityGameID] copy];
   _placementID = [[[strongConnector credentials] objectForKey:kGADMAdapterUnityPlacementID] copy];
   if (!_gameID || !_placementID) {
-    NSError *error = GADUnityErrorWithDescription(kMISSING_ID_ERROR);
+     NSError *error = GADMAdapterUnityErrorWithCodeAndDescription(
+           GADMAdapterUnityErrorInvalidServerParameters, @"Game ID and Placement ID cannot be nil.");
     [strongConnector adapter:strongAdapter didFailAd:error];
     return;
   }
@@ -150,7 +152,8 @@
   id<GADMAdNetworkConnector> strongConnector = _connector;
   id<GADMAdNetworkAdapter> strongAdapter = _adapter;
   if (strongConnector && strongAdapter) {
-    NSError *error = GADUnityErrorWithDescription([NSString stringWithFormat:@"Failed to load interstitial ad with placement ID '%@'", placementId]);
+    NSString *errorMsg = [NSString stringWithFormat:@"No ad available for the placement ID: %@", _placementID];
+      NSError *error = GADMAdapterUnityErrorWithCodeAndDescription(GADMAdapterUnityErrorPlacementStateNoFill, errorMsg);
     [strongConnector adapter:strongAdapter didFailAd:error];
   }
 }

--- a/adapters/Unity/UnityAdapter/GADMediationAdapterUnity.m
+++ b/adapters/Unity/UnityAdapter/GADMediationAdapterUnity.m
@@ -34,14 +34,14 @@
     NSString *gameIDFromSettings = cred.settings[kGADMAdapterUnityGameID];
     GADMAdapterUnityMutableSetAddObject(gameIDs, gameIDFromSettings);
   }
-  
+
   if (!gameIDs.count) {
     NSError *error = GADMAdapterUnityErrorWithCodeAndDescription(GADMAdapterUnityErrorInvalidServerParameters,
                                                                  @"UnityAds mediation configurations did not contain a valid game ID.");
     completionHandler(error);
     return;
   }
-  
+
   NSString *gameID = [gameIDs anyObject];
   if (gameIDs.count > 1) {
     NSLog(@"Found the following game IDs: %@. "
@@ -88,7 +88,8 @@
 }
 
 - (void)loadRewardedAdForAdConfiguration:(GADMediationRewardedAdConfiguration *)adConfiguration
-                       completionHandler:(GADMediationRewardedLoadCompletionHandler)completionHandler {
+                       completionHandler:
+                           (GADMediationRewardedLoadCompletionHandler)completionHandler {
   self.rewardedAd = [[GADMAdapterUnityRewardedAd alloc] initWithAdConfiguration:adConfiguration
                                                               completionHandler:completionHandler];
   [self.rewardedAd requestRewardedAd];

--- a/adapters/Unity/UnityAdapter/GADUnityError.h
+++ b/adapters/Unity/UnityAdapter/GADUnityError.h
@@ -14,9 +14,6 @@
 
 #import <Foundation/Foundation.h>
 
-/// Missing gameID or placementID
-static NSString *const kMISSING_ID_ERROR = @"Game ID and Placement ID cannot be nil.";
-
 /// Returns an NSError with NSLocalizedDescriptionKey and NSLocalizedFailureReasonErrorKey values
 /// set to |description|.
 NSError *GADUnityErrorWithDescription(NSString *description);


### PR DESCRIPTION
Error handling is designed by creating NSError via `GADMAdapterUnityErrorWithCodeAndDescription` and pass it to GADMAdNetworkConnector. 

This logic is modified and broken in 3.5.0 adapter updates.