### PR TITLE
<chore>(UADSDK-2290):<iOS>: Add objectId for Load/Show API calls in Waterfall.

### DIFF
--- a/adapters/Unity/UnityAdapter/GADMAdapterUnity.m
+++ b/adapters/Unity/UnityAdapter/GADMAdapterUnity.m
@@ -25,6 +25,7 @@
 @property(nonatomic, weak) id<GADMAdNetworkConnector> connector;
 @property(nonatomic, strong) UADSBannerView *bannerAd;
 @property(nonatomic, strong) GADMUnityBannerNetworkAdapterProxy *bannerAdDelegateProxy;
+@property(nonatomic, strong) NSString *objectId;
 @end
 
 @implementation GADMAdapterUnity
@@ -62,16 +63,23 @@
 }
 
 - (void)getInterstitial {
+  self.objectId = [NSUUID UUID].UUIDString;
+  UADSLoadOptions *loadOptions = [UADSLoadOptions new];
+  loadOptions.objectId = self.objectId;
   [UnityAds load:[[self.connector credentials] objectForKey:GADMAdapterUnityPlacementID] ?: @""
-      loadDelegate:[[GADMUnityInterstitialNetworkAdapterProxy alloc]
+         options:loadOptions
+    loadDelegate:[[GADMUnityInterstitialNetworkAdapterProxy alloc]
                        initWithGADMAdNetworkConnector:self.connector
                                               adapter:self]];
 }
 
 - (void)presentInterstitialFromRootViewController:(UIViewController *)rootViewController {
+  UADSShowOptions *showOptions = [UADSShowOptions new];
+  showOptions.objectId = self.objectId;
   [UnityAds show:rootViewController
-       placementId:[[self.connector credentials] objectForKey:GADMAdapterUnityPlacementID] ?: @""
-      showDelegate:[[GADMUnityInterstitialNetworkAdapterProxy alloc]
+     placementId:[[self.connector credentials] objectForKey:GADMAdapterUnityPlacementID] ?: @""
+         options:showOptions
+    showDelegate:[[GADMUnityInterstitialNetworkAdapterProxy alloc]
                        initWithGADMAdNetworkConnector:self.connector
                                               adapter:self]];
 }

--- a/adapters/Unity/UnityAdapter/GADMediationAdapterUnity.m
+++ b/adapters/Unity/UnityAdapter/GADMediationAdapterUnity.m
@@ -28,6 +28,7 @@
 @property(nonatomic, strong) NSString *placementId;
 @property(nonatomic, strong) GADUnityBaseMediationAdapterProxy *adapterProxy;
 @property(nonatomic, strong) UADSBannerView *bannerView;
+@property(nonatomic, strong) NSString *objectId; // Object ID used to track loaded/shown ads.
 @end
 
 @implementation GADMediationAdapterUnity
@@ -89,8 +90,13 @@
   [self initializeWithConfiguration:adConfiguration];
 
   self.placementId = adConfiguration.placementId;
-
-  [UnityAds load:self.placementId loadDelegate:self.adapterProxy];
+  self.objectId = [NSUUID UUID].UUIDString;
+  UADSLoadOptions *loadOptions = [UADSLoadOptions new];
+  loadOptions.objectId = self.objectId;
+  
+  [UnityAds load:self.placementId
+         options:loadOptions
+    loadDelegate:self.adapterProxy];
 }
 
 - (void)loadBannerForAdConfiguration:(GADMediationBannerAdConfiguration *)adConfiguration
@@ -114,7 +120,12 @@
 }
 
 - (void)presentFromViewController:(nonnull UIViewController *)viewController {
-  [UnityAds show:viewController placementId:self.placementId showDelegate:self.adapterProxy];
+  UADSShowOptions *showOptions = [UADSShowOptions new];
+  showOptions.objectId = self.objectId;
+  [UnityAds show:viewController
+     placementId:self.placementId
+         options:showOptions
+    showDelegate:self.adapterProxy];
 }
 
 - (void)initializeWithConfiguration:(GADMediationAdConfiguration *)adConfiguration {


### PR DESCRIPTION
To improve fill expectation issues, enhance tracking and provide sequential caching, we must add Object ID to load and show request of an Ad Unit.

This PR is to add a UUID when issuing Load request and use the same (as object ID) when doing the Show call later.

Manually tested in Waterfall that we send Load and Show options as expected in the adapter.